### PR TITLE
New GR feature gr-meta will give gr-crystal the power to create beautiful figures.

### DIFF
--- a/src/grlib.cr
+++ b/src/grlib.cr
@@ -101,7 +101,13 @@ lib LibGR
   fun gr_setarrowstyle(i: Int32)
   fun gr_setarrowsize(x: Float64)
   fun gr_drawarrow(x: Float64, x1: Float64, x2: Float64, x3: Float64)
+end
 
+@[Link(ldflags: "-L `echo $GRDIR`/lib -lGRM -Wl,-rpath,`echo $GRDIR`/lib")]
+lib LibGRM
+  fun grm_args_new() : Pointer(Int32)
+  fun grm_args_push(grm_args_t: Int32*, key: UInt8*, value_foramt: UInt8*, ...)
+  fun grm_plot(grm_args_t: Int32*)
 end
 
 module GR


### PR DESCRIPTION
This is an attempt to draw a graph from Crystal using GRM.
Do not merge this PR because because my pointer usage is wrong. 
But it works.

```crystal
require "grlib"

n = 1000
x = [] of Float64
y = [] of Float64
z = [] of Float64
n.times do |i|
  x << i * 30.0 / n
  y << Math.cos(x[i]) * x[i]
  z << Math.sin(x[i]) * x[i]
end

args = LibGRM.grm_args_new
LibGRM.grm_args_push(args, "kind", "s", "plot3")
LibGRM.grm_args_push(args, "x", "nD", n, x)
LibGRM.grm_args_push(args, "y", "nD", n, y)
LibGRM.grm_args_push(args, "z", "nD", n, z)

LibGRM.grm_plot(args)

c=gets
```

![image](https://user-images.githubusercontent.com/5798442/87663940-78490400-c79f-11ea-9f28-7c85cf0c7e12.png)

```crystal
LibGRM.grm_args_push(args, "kind", "s", "surface")
```

![image](https://user-images.githubusercontent.com/5798442/87664167-c52cda80-c79f-11ea-9e38-acba71ed88e4.png)


```crystal
LibGRM.grm_args_push(args, "kind", "s", "hexbin")
```

![image](https://user-images.githubusercontent.com/5798442/87664283-f0172e80-c79f-11ea-93f1-c9f13514cda5.png)

```crystal
LibGRM.grm_args_push(args, "kind", "s", "wireframe")
```

![image](https://user-images.githubusercontent.com/5798442/87664474-44baa980-c7a0-11ea-81ac-d567988611b0.png)

```crystal
LibGRM.grm_args_push(args, "kind", "s", "stem")
```

![image](https://user-images.githubusercontent.com/5798442/87664562-69af1c80-c7a0-11ea-8818-cbdad92def42.png)

```crystal
LibGRM.grm_args_push(args, "kind", "s", "contour")
```

![image](https://user-images.githubusercontent.com/5798442/87664637-8ea38f80-c7a0-11ea-8e12-ddc4df14a757.png)


```crystal
LibGRM.grm_args_push(args, "kind", "s", "contourf")
```

![image](https://user-images.githubusercontent.com/5798442/87664747-c14d8800-c7a0-11ea-9c36-2b467759220b.png)

```crystal
LibGRM.grm_args_push(args, "kind", "s", "scatter")
LibGRM.grm_args_push(args, "x", "nD", n, x)
LibGRM.grm_args_push(args, "y", "nD", n, y)
LibGRM.grm_args_push(args, "c", "nD", n, z)

```

![image](https://user-images.githubusercontent.com/5798442/87665401-d5de5000-c7a1-11ea-934a-d8ec498f28d9.png)


And so on...